### PR TITLE
Basic canvas element resizing behaviour

### DIFF
--- a/client/src/Renderer.ts
+++ b/client/src/Renderer.ts
@@ -40,9 +40,9 @@ export enum DisplayType {
 export class Renderer {
 
     public gl: Context;
-    private canvas: Node;
+    private canvas: HTMLCanvasElement;
     private frameBuffer: WebGLFramebuffer;
-    
+
     private pass_prog: Shader;
     private diagnostic_prog: Shader;
 
@@ -79,11 +79,15 @@ export class Renderer {
 
     private ext: any;
 
+    private canvasClientWidth: number;
+    private canvasClientHeight: number;
+
     constructor() {
 
         // Creates a canvas element and attaches
         // it to the <body> on your DOM.hello richard, i loveyou x
-        this.canvas = document.body.appendChild(document.createElement('canvas'));
+        this.canvas = document.createElement("canvas");
+        document.body.appendChild(this.canvas);
 
         // Creates an instance of look-at camera and orbit camera.
         this.lookAtCamera = new LookAtCamera();
@@ -108,10 +112,22 @@ export class Renderer {
 
         // Resizes the <canvas> to fully fit the window
         // whenever the window is resized.
-        window.addEventListener('resize'
-            , fit(this.canvas)
-            , false
-        )
+        window.addEventListener('resize', () => {
+            this.canvasClientWidth = this.canvas.clientWidth;
+            this.canvasClientHeight = this.canvas.clientHeight;
+
+            //http://stackoverflow.com/questions/4938346/canvas-width-and-height-in-html5
+            //gl.clearRect
+        });
+
+        this.canvasClientWidth = this.canvas.clientWidth;
+        this.canvasClientHeight = this.canvas.clientHeight;
+        // Now set the canvas to be upscaled.
+        this.canvas.height = this.canvasClientHeight / 2;
+        this.canvas.width = this.canvasClientWidth / 2;
+
+        // TODO: Some styling will be needed to maintain aspect ratio.
+
 
         this.gl.getExtension("OES_texture_float");
         this.gl.getExtension("OES_half_float_linear");

--- a/client/src/Renderer.ts
+++ b/client/src/Renderer.ts
@@ -86,8 +86,7 @@ export class Renderer {
 
         // Creates a canvas element and attaches
         // it to the <body> on your DOM.hello richard, i loveyou x
-        this.canvas = document.createElement("canvas");
-        document.body.appendChild(this.canvas);
+        this.canvas = <HTMLCanvasElement>document.querySelector(".primary-canvas");
 
         // Creates an instance of look-at camera and orbit camera.
         this.lookAtCamera = new LookAtCamera();
@@ -113,18 +112,27 @@ export class Renderer {
         // Resizes the <canvas> to fully fit the window
         // whenever the window is resized.
         window.addEventListener('resize', () => {
-            this.canvasClientWidth = this.canvas.clientWidth;
-            this.canvasClientHeight = this.canvas.clientHeight;
+            if (this.canvasClientHeight !== this.canvas.clientHeight &&
+                this.canvasClientWidth !== this.canvas.clientWidth ) {
 
-            //http://stackoverflow.com/questions/4938346/canvas-width-and-height-in-html5
-            //gl.clearRect
+                this.canvasClientWidth = this.canvas.clientWidth;
+                this.canvasClientHeight = this.canvas.clientHeight;
+            
+                this.canvas.height = this.canvasClientHeight;
+                this.canvas.width = this.canvasClientWidth;
+
+                this.setupFrameBufferTextures();
+
+                //http://stackoverflow.com/questions/4938346/canvas-width-and-height-in-html5
+                //gl.clearRect
+            }
         });
 
         this.canvasClientWidth = this.canvas.clientWidth;
         this.canvasClientHeight = this.canvas.clientHeight;
         // Now set the canvas to be upscaled.
-        this.canvas.height = this.canvasClientHeight / 2;
-        this.canvas.width = this.canvasClientWidth / 2;
+        this.canvas.height = this.canvasClientHeight;
+        this.canvas.width = this.canvasClientWidth;
 
         // TODO: Some styling will be needed to maintain aspect ratio.
 
@@ -133,27 +141,10 @@ export class Renderer {
         this.gl.getExtension("OES_half_float_linear");
         this.gl.getExtension("OES_texture_float_linear");
         
-        // Defaults to magFilter/minFilter = NEAREST, wrap = CLAMP_TO_EDGE.
-        this.depthTexture = createTexture(this.gl, this.gl.drawingBufferWidth, this.gl.drawingBufferHeight, this.gl.DEPTH_COMPONENT, this.gl.UNSIGNED_SHORT);
-
-        this.depthRGBTexture = createTexture(this.gl, this.gl.drawingBufferWidth, this.gl.drawingBufferHeight, this.gl.RGBA, this.gl.FLOAT);        
-        this.depthRGBTexture.magFilter = this.gl.LINEAR;
-        this.depthRGBTexture.minFilter = this.gl.LINEAR;
-
-        this.normalTexture = createTexture(this.gl, this.gl.drawingBufferWidth, this.gl.drawingBufferHeight, this.gl.RGBA, this.gl.FLOAT);
-        this.normalTexture.magFilter = this.gl.LINEAR;
-        this.normalTexture.minFilter = this.gl.LINEAR;
-
-        this.positionTexture = createTexture(this.gl, this.gl.drawingBufferWidth, this.gl.drawingBufferHeight, this.gl.RGBA, this.gl.FLOAT);
-        this.positionTexture.magFilter = this.gl.LINEAR;
-        this.positionTexture.minFilter = this.gl.LINEAR;
-
-        this.colorTexture = createTexture(this.gl, this.gl.drawingBufferWidth, this.gl.drawingBufferHeight, this.gl.RGBA, this.gl.FLOAT);
-        this.colorTexture.magFilter = this.gl.LINEAR;
-        this.colorTexture.minFilter = this.gl.LINEAR;
+        
 
         // Create and bind framebuffer object.
-        this.frameBuffer = this.gl.createFramebuffer();
+        this.frameBuffer = this.gl.createFramebuffer();       
         this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, this.frameBuffer);      
 
 
@@ -166,21 +157,7 @@ export class Renderer {
             this.ext.COLOR_ATTACHMENT3_WEBGL  // gl_FragData[3] Depth
         ]);
 
-        // Setup deferred shading by attaching textures to different frame buffer color attachments.
-        this.gl.framebufferTexture2D(this.gl.FRAMEBUFFER, this.ext.COLOR_ATTACHMENT0_WEBGL, this.gl.TEXTURE_2D, this.normalTexture.handle, 0);
-        this.gl.framebufferTexture2D(this.gl.FRAMEBUFFER, this.ext.COLOR_ATTACHMENT1_WEBGL, this.gl.TEXTURE_2D, this.colorTexture.handle, 0);
-        this.gl.framebufferTexture2D(this.gl.FRAMEBUFFER, this.ext.COLOR_ATTACHMENT2_WEBGL, this.gl.TEXTURE_2D, this.positionTexture.handle, 0);
-        this.gl.framebufferTexture2D(this.gl.FRAMEBUFFER, this.ext.COLOR_ATTACHMENT3_WEBGL, this.gl.TEXTURE_2D, this.depthRGBTexture.handle, 0);
-        this.gl.framebufferTexture2D(this.gl.FRAMEBUFFER, this.gl.DEPTH_ATTACHMENT, this.gl.TEXTURE_2D, this.depthTexture.handle, 0);
-        
-
-        if (this.gl.checkFramebufferStatus(this.gl.FRAMEBUFFER) !== this.gl.FRAMEBUFFER_COMPLETE) {
-            // Can't use framebuffer.
-            // See http://www.khronos.org/opengles/sdk/docs/man/xhtml/glCheckFramebufferStatus.xml
-            console.log("Frame buffer initialisation failed");
-        } else {
-            console.log("Frame buffer initialisation success");
-        }
+        this.setupFrameBufferTextures();
 
         //programs:
         // 1. pass_prog
@@ -234,6 +211,61 @@ export class Renderer {
         this.gl.bufferData(this.gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(indices), this.gl.STATIC_DRAW);        
         
         this.display_type = DisplayType.Total;
+    }
+
+    private setupFrameBufferTextures(): void {
+
+        this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, this.frameBuffer);
+
+        // Defaults to magFilter/minFilter = NEAREST, wrap = CLAMP_TO_EDGE.
+        if (this.depthTexture) {
+            this.depthTexture.dispose();
+        }
+        this.depthTexture = createTexture(this.gl, this.gl.drawingBufferWidth, this.gl.drawingBufferHeight, this.gl.DEPTH_COMPONENT, this.gl.UNSIGNED_SHORT);
+
+        if (this.depthRGBTexture) {
+            this.depthRGBTexture.dispose();
+        }
+        this.depthRGBTexture = createTexture(this.gl, this.gl.drawingBufferWidth, this.gl.drawingBufferHeight, this.gl.RGBA, this.gl.FLOAT);
+        this.depthRGBTexture.magFilter = this.gl.LINEAR;
+        this.depthRGBTexture.minFilter = this.gl.LINEAR;
+
+        if (this.normalTexture) {
+            this.normalTexture.dispose();
+        }
+        this.normalTexture = createTexture(this.gl, this.gl.drawingBufferWidth, this.gl.drawingBufferHeight, this.gl.RGBA, this.gl.FLOAT);
+        this.normalTexture.magFilter = this.gl.LINEAR;
+        this.normalTexture.minFilter = this.gl.LINEAR;
+
+        if (this.positionTexture) {
+            this.positionTexture.dispose();
+        }
+        this.positionTexture = createTexture(this.gl, this.gl.drawingBufferWidth, this.gl.drawingBufferHeight, this.gl.RGBA, this.gl.FLOAT);
+        this.positionTexture.magFilter = this.gl.LINEAR;
+        this.positionTexture.minFilter = this.gl.LINEAR;
+
+        if (this.colorTexture) {
+            this.colorTexture.dispose();
+        }
+        this.colorTexture = createTexture(this.gl, this.gl.drawingBufferWidth, this.gl.drawingBufferHeight, this.gl.RGBA, this.gl.FLOAT);
+        this.colorTexture.magFilter = this.gl.LINEAR;
+        this.colorTexture.minFilter = this.gl.LINEAR;
+
+        // Setup deferred shading by attaching textures to different frame buffer color attachments.
+        this.gl.framebufferTexture2D(this.gl.FRAMEBUFFER, this.ext.COLOR_ATTACHMENT0_WEBGL, this.gl.TEXTURE_2D, this.normalTexture.handle, 0);
+        this.gl.framebufferTexture2D(this.gl.FRAMEBUFFER, this.ext.COLOR_ATTACHMENT1_WEBGL, this.gl.TEXTURE_2D, this.colorTexture.handle, 0);
+        this.gl.framebufferTexture2D(this.gl.FRAMEBUFFER, this.ext.COLOR_ATTACHMENT2_WEBGL, this.gl.TEXTURE_2D, this.positionTexture.handle, 0);
+        this.gl.framebufferTexture2D(this.gl.FRAMEBUFFER, this.ext.COLOR_ATTACHMENT3_WEBGL, this.gl.TEXTURE_2D, this.depthRGBTexture.handle, 0);
+        this.gl.framebufferTexture2D(this.gl.FRAMEBUFFER, this.gl.DEPTH_ATTACHMENT, this.gl.TEXTURE_2D, this.depthTexture.handle, 0);
+        
+
+        if (this.gl.checkFramebufferStatus(this.gl.FRAMEBUFFER) !== this.gl.FRAMEBUFFER_COMPLETE) {
+            // Can't use framebuffer.
+            // See http://www.khronos.org/opengles/sdk/docs/man/xhtml/glCheckFramebufferStatus.xml
+            console.log("Frame buffer initialisation failed");
+        } else {
+            console.log("Frame buffer initialisation success");
+        }
     }
 
     public render(drawUnits: DrawUnit[]): void {        

--- a/client/src/ambient/stackgl.d.ts
+++ b/client/src/ambient/stackgl.d.ts
@@ -355,6 +355,7 @@ declare module "stackgl" {
 
         handle: WebGLTexture;
         bind(texunit: number): void;
+        dispose(): void;
 
         shape: number[];
         wrap: number[];

--- a/server/app/views/worldview/index.scala.html
+++ b/server/app/views/worldview/index.scala.html
@@ -1,7 +1,29 @@
 @()(implicit request: RequestHeader)
 
 <h2>Home</h2>
-<div>
-  Hello, I am the World View page.
-</div>
+
+<style>
+
+  .primary-canvas {
+    margin: auto;
+    display: block;
+  }
+
+  @@media (min-width:600px) {
+    .primary-canvas {
+      width: 600px;
+    }
+  }
+
+  @@media (max-width:600px) {
+    .primary-canvas {
+      width: 300px;
+    }
+  }
+
+
+</style>
+
+<canvas class="primary-canvas"></canvas>
+
 <script charset="utf-8" src="@{common.AssetLoader.getPath("app.js")}"></script>


### PR DESCRIPTION
Adding a few media queries to resize the canvas element client dimensions. Remember, the canvas' style-based client width/height may not match the canvas width/height. But we use `setupFrameBufferTextures` to synchronise them.
